### PR TITLE
Update ratchet dependency: attributes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule PhoenixRatchet.Mixfile do
     [
       {:phoenix, "~> 1.1"},
       {:phoenix_html, "~> 2.5"},
-      {:ratchet, "~> 0.0.4"},
+      {:ratchet, ">= 0.2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "floki": {:hex, :floki, "0.8.0", "3ee6f8358e9f820d80f8211558458364cd137d1a7b362eb1d1989120dc288fa9", [:mix], [{:mochiweb_html, "~> 2.13", [hex: :mochiweb_html, optional: false]}]},
-  "mochiweb_html": {:hex, :mochiweb_html, "2.13.0", "795b100f757681939e2c52ab042e773af6e5602f04f4e2ea19baea832b541c08", [:rebar3], []},
+  "floki": {:hex, :floki, "0.8.1", "06aa75bf2d1e01cda7d2ad54f68614be653a11e76b474d8fcb1d838f8c1e0ad1", [:mix], [{:mochiweb_html, "~> 2.15", [hex: :mochiweb_html, optional: false]}]},
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], []},
   "phoenix": {:hex, :phoenix, "1.1.4", "65809fba92eb94377372a5fb5a561197654bb8406e773cc47ca1a031bbe58019", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.5.1", "631053f9e345fecb5c87d9e0ccd807f7266d27e2ee4269817067af425fd81ba8", [:mix], [{:plug, "~> 0.13 or ~> 1.0", [hex: :plug, optional: false]}]},
   "plug": {:hex, :plug, "1.1.4", "2eee0e85ad420db96e075b3191d3764d6fff61422b101dc5b02e9cce99cacfc7", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "ratchet": {:hex, :ratchet, "0.0.4", "08e7b059719e3bc5890f9cd3f2c2efcd17c493d4ddac65797c33e8e537c531ed", [:mix], [{:floki, "~> 0.8", [hex: :floki, optional: false]}]}}
+  "ratchet": {:hex, :ratchet, "0.2.0", "8d063fd70747e4315bbfa0a9fa72d315774f9e5b7aaa9c6a1b7e26941bced1d7", [:mix], [{:phoenix_html, "~> 2.5.1", [hex: :phoenix_html, optional: false]}, {:floki, "~> 0.8", [hex: :floki, optional: false]}]}}

--- a/test/ratchet/phoenix/engine_test.exs
+++ b/test/ratchet/phoenix/engine_test.exs
@@ -12,8 +12,8 @@ defmodule Ratchet.Phoenix.EngineTest do
 
   test "render a ratchet template" do
     data = %{post: %{title: "OHAI", body: "COOL"}}
-    result = View.render(TestView, "posts.html", data: data)
+    result = View.render(TestView, "posts.html", data: data) |> Phoenix.HTML.safe_to_string
 
-    assert result == {:safe, [[["" | "<section>"], [[[["" | "<article data-scope=\"post\">"], [[["" | "<h1 data-prop=\"title\">"] | "OHAI"] | "</h1>"]], [[["" | "<p data-prop=\"body\">"] | "COOL"] | "</p>"]] | "</article>"]] | "</section>"]}
+    assert result == ~S(<section><article data-scope="post"><h1 data-prop="title">OHAI</h1><p data-prop="body">COOL</p></article></section>)
   end
 end

--- a/test/ratchet/phoenix/engine_test.exs
+++ b/test/ratchet/phoenix/engine_test.exs
@@ -11,9 +11,9 @@ defmodule Ratchet.Phoenix.EngineTest do
   end
 
   test "render a ratchet template" do
-    data = %{post: %{title: "OHAI", body: "COOL"}}
+    data = %{post: %{title: {"OHAI", class: "large"}, body: "COOL"}}
     result = View.render(TestView, "posts.html", data: data) |> Phoenix.HTML.safe_to_string
 
-    assert result == ~S(<section><article data-scope="post"><h1 data-prop="title">OHAI</h1><p data-prop="body">COOL</p></article></section>)
+    assert result == ~S(<section><article data-scope="post"><h1 class="large" data-prop="title">OHAI</h1><p data-prop="body">COOL</p></article></section>)
   end
 end


### PR DESCRIPTION
Tweak test to keep it passing. This version of ratchet supports dynamic
property attributes, so they are now separated in the compiled view.

Went ahead and tweaked the compatible ratchet versions for this engine. Can use any version greater than current one. May have to lock it down further in the future, but maybe this will make things more flexible.
