### PR TITLE
Make data composable by making data modules pluggable

### DIFF
--- a/lib/ratchet/plug/data.ex
+++ b/lib/ratchet/plug/data.ex
@@ -49,11 +49,18 @@ defmodule Ratchet.Plug.Data do
 
       def property, do: unquote(property)
 
-      @behaviour Plug
-      def init(_opts), do: false
-      def call(conn, _opts) do
+      @before_compile unquote(__MODULE__)
+      use Plug.Builder
+
+      defp merge_data(conn, _opts) do
         unquote(__MODULE__).merge(conn, %{property => data(conn)})
       end
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      plug :merge_data
     end
   end
 

--- a/test/ratchet/plug/data_test.exs
+++ b/test/ratchet/plug/data_test.exs
@@ -3,8 +3,14 @@ defmodule Ratchet.Plug.DataTest do
   alias Ratchet.Plug.Data
   doctest Data
 
+  defmodule Bar do
+    use Data, for: :bar
+    def data(_), do: "value"
+  end
+
   defmodule Foo do
     use Data, for: :foos
+    plug Bar
     def data(conn), do: "foo #{conn.assigns.data.bar}"
   end
 
@@ -12,7 +18,7 @@ defmodule Ratchet.Plug.DataTest do
     assert Foo.property == :foos
   end
 
-  @conn %Plug.Conn{assigns: %{data: %{bar: "value"}}}
+  @conn %Plug.Conn{assigns: %{data: %{}}}
 
   test "pluggable" do
     conn = Foo.call(@conn, [])


### PR DESCRIPTION
This allows additional transformations to be made within the data module itself. Phoenix: plugs all the way down™
