### PR TITLE
Allow prototype to be rendered with no data in connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Rename endpoint used by Ratchet (https://github.com/iamvery/phoenix_ratchet/pull/17)
 - Serialize data for the wire using special format for tuple data (https://github.com/iamvery/phoenix_ratchet/pull/14)
 - Ratchet.Plug.Data is itself pluggable (https://github.com/iamvery/phoenix_ratchet/pull/21)
+- Render prototype when no data is present in connection (https://github.com/iamvery/phoenix_ratchet/pull/25)
 
 ## [0.3.1] - 2016-07-19
 ## [0.3.0] - 2016-07-19

--- a/lib/ratchet/phoenix/engine.ex
+++ b/lib/ratchet/phoenix/engine.ex
@@ -12,7 +12,7 @@ defmodule Ratchet.Phoenix.Engine do
     path
     |> read
     |> parse
-    |> transform("assigns.data")
+    |> transform("assigns[:data]") # TODO seems peculiar that this bit is elixir code in a string. Perhaps a quoted expression would be more appropriate?
     |> compile
     |> EEx.compile_string(engine: Phoenix.HTML.Engine, file: path, line: 1)
   end

--- a/test/fixtures/templates/posts.html.ratchet
+++ b/test/fixtures/templates/posts.html.ratchet
@@ -1,6 +1,6 @@
 <section>
   <article data-prop="post">
-    <h1 data-prop="title"></h1>
-    <p data-prop="body"></p>
+    <h1 data-prop="title">Title</h1>
+    <p data-prop="body">Body</p>
   </article>
 </section>

--- a/test/ratchet/phoenix/engine_test.exs
+++ b/test/ratchet/phoenix/engine_test.exs
@@ -16,4 +16,10 @@ defmodule Ratchet.Phoenix.EngineTest do
 
     assert result == ~S(<section><article data-prop="post"><h1 class="large" data-prop="title">OHAI</h1><p data-prop="body">COOL</p></article></section>)
   end
+
+  test "render prototype when data is not provided" do
+    result = View.render(TestView, "posts.html", []) |> Phoenix.HTML.safe_to_string
+
+    assert result == ~S(<section><article data-prop="post"><h1 data-prop="title">Title</h1><p data-prop="body">Body</p></article></section>)
+  end
 end


### PR DESCRIPTION
The []/1 access function is more forgiving than dot access. In this
case, a missing key returns nil which plays nicely with how Ratchet
transforms views.

[fixes iamvery/ratchet#45]
[closes #8]
